### PR TITLE
Basic shell script with Git dependency

### DIFF
--- a/updater_pixy.bat
+++ b/updater_pixy.bat
@@ -1,0 +1,14 @@
+@ECHO OFF
+
+TITLE KanColle English Patch Updater ver. Pixy
+WHERE git
+IF %ERRORLEVEL% NEQ 0 GOTO CommandNotFound
+git pull -f origin master
+
+GOTO UpdaterEnd
+:CommandNotFound
+ECHO "Git wasn't found on this system."
+ECHO "Please install from https://git-scm.com/download/win ."
+ECHO "Follow the installation instructions and use all default settings."
+:UpdaterEnd
+PAUSE


### PR DESCRIPTION
This shell script should only run if the user has Git. If it does run, it simply forces a pull to ensure proper behavior.